### PR TITLE
A function SHOULD NOT return ctx.Err() if the method was not interrupted because of the context passed to a function

### DIFF
--- a/exporters/jaeger/jaeger.go
+++ b/exporters/jaeger/jaeger.go
@@ -115,11 +115,6 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpa
 func (e *Exporter) Shutdown(ctx context.Context) error {
 	// Stop any active and subsequent exports.
 	e.stopOnce.Do(func() { close(e.stopCh) })
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
 	return e.uploader.shutdown(ctx)
 }
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -149,7 +149,7 @@ func (c *client) Shutdown(ctx context.Context) error {
 
 	c.requestFunc = nil
 	c.httpClient = nil
-	return ctx.Err()
+	return nil
 }
 
 // UploadMetrics sends protoMetrics to the connected endpoint.

--- a/exporters/stdout/stdoutmetric/exporter.go
+++ b/exporters/stdout/stdoutmetric/exporter.go
@@ -87,7 +87,7 @@ func (e *exporter) Shutdown(ctx context.Context) error {
 			encoder: shutdownEncoder{},
 		})
 	})
-	return ctx.Err()
+	return nil
 }
 
 func redactTimestamps(orig *metricdata.ResourceMetrics) {


### PR DESCRIPTION
A function SHOULD NOT return ctx.Err() if the method was not interrupted because of the context passed to a function

A function should return `ctx.Err()` if the context is cancelled, except if there is no work in progress. In that case, it should return `nil`. 

`ctx.Err()` is returned usually in function that has the "processing logic" 